### PR TITLE
fix

### DIFF
--- a/src/pages/userstats.js
+++ b/src/pages/userstats.js
@@ -194,6 +194,8 @@ export default function UserStats() {
   const [audioFeatures, setAudioFeatures] = useState({});
   const [dataTimeframe, setDataTimeframe] = useState("short_term");
 
+  const [user, setUser] = useState({});
+
   const auth = useSelector(getAuth);
   const loggedIn = auth.loggedIn;
 
@@ -202,6 +204,7 @@ export default function UserStats() {
     if (loggedIn) {
       fetchTopArtists();
       fetchTopTracks();
+      fetchspotifyuser();
     } else {
       console.log("not logged in!");
     }
@@ -210,6 +213,20 @@ export default function UserStats() {
   useEffect(() => {
     if (topTracks !== {}) fetchAudioFeatures();
   }, [topTracks]);
+
+  async function fetchspotifyuser() {
+    try {
+      const url = `https://api.spotify.com/v1/me`;
+      const result = await get(url, { access_token: auth.accessToken });
+      console.log("fetch spotify user result:", result);
+      setUser(result || {});
+    } catch (e) {
+      if (e instanceof DOMException) {
+        console.log("HTTP Request Aborted");
+      }
+      console.log("error fetching user", e);
+    }
+  }
 
   async function fetchAudioFeatures() {
     try {
@@ -650,7 +667,7 @@ export default function UserStats() {
       return (
         <div id="cat-container" style={containerCss}>
           <Jumbotron>
-            <h1 class="display-4">Your Purrsona</h1>
+            <h1 class="display-4">{user.display_name}'s Purrsona</h1>
             <p class="lead">
               Have a cat visualization created based on your spotify data!
             </p>

--- a/src/pages/userstats.js
+++ b/src/pages/userstats.js
@@ -686,7 +686,7 @@ export default function UserStats() {
       <ButtonGroup>
         <OverlayTrigger
           placement="bottom"
-          overlay={explanationTooltip("The last 4 weeks")}
+          overlay={explanationTooltip("Last 4 weeks")}
         >
           <Button
             className={
@@ -701,7 +701,7 @@ export default function UserStats() {
         </OverlayTrigger>
         <OverlayTrigger
           placement="bottom"
-          overlay={explanationTooltip("The last 6 months")}
+          overlay={explanationTooltip("Last 6 months")}
         >
           <Button
             className={
@@ -716,7 +716,7 @@ export default function UserStats() {
         </OverlayTrigger>
         <OverlayTrigger
           placement="bottom"
-          overlay={explanationTooltip("All data")}
+          overlay={explanationTooltip("Last year")}
         >
           <Button
             className={dataTimeframe === "long_term" ? "active-button" : "card"}


### PR DESCRIPTION
spotify time ranges does not include all data but just the most recent year

https://developer.spotify.com/documentation/web-api/reference/get-users-top-artists-and-tracks

time_range
string
Over what time frame the affinities are computed. Valid values: long_term (calculated from ~1 year of data and including all new data as it becomes available), medium_term (approximately last 6 months), short_term (approximately last 4 weeks). Default: medium_term

Default: time_range=medium_term
Example: time_range=medium_term

